### PR TITLE
Pin Python to 3.12 to restore build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /js
 COPY kobra-client /js
 RUN pwd && npm install && npm run build
 
-FROM python:alpine
+FROM python:3.12-alpine
 
 # Set work directory
 WORKDIR /app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker runtime environment to Python 3.12 Alpine, establishing a more stable and explicitly versioned Python baseline for the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->