### PR TITLE
fix: handle fan/report MQTT messages in parse_message()

### DIFF
--- a/main.py
+++ b/main.py
@@ -237,6 +237,13 @@ def temperature_message(printer: Printer, payload):
           f"{printer.hotbed_temp}/{printer.target_hotbed_temp}°C Hotbed")
 
 
+def fan_message(printer: Printer, payload):
+    fan_speed = payload["data"].get("fan_speed_pct")
+    if fan_speed is not None and printer.print_job is not None:
+        printer.print_job.fan_speed = fan_speed
+        print(f"+++ Printer {printer.id} fan speed: {fan_speed}%")
+
+
 def file_message(printer: Printer, payload):
     action = payload["action"]
     if action in ["listLocal", "listUdisk"]:
@@ -361,6 +368,8 @@ def parse_message(mqtt_client, userdata, message):
             print_message(this_printer, payload)
         elif type == "ota":
             ota_message(this_printer, payload)
+        elif type == "fan":
+            fan_message(this_printer, payload)
         elif type == "lastWill":
             lastwill_message(this_printer, payload)
         else:

--- a/main.py
+++ b/main.py
@@ -237,11 +237,14 @@ def temperature_message(printer: Printer, payload):
           f"{printer.hotbed_temp}/{printer.target_hotbed_temp}°C Hotbed")
 
 
-def fan_message(printer: Printer, payload):
-    fan_speed = payload["data"].get("fan_speed_pct")
+def fan_message(printer: Printer, payload) -> bool:
+    data = payload.get("data") or {}
+    fan_speed = data.get("fan_speed_pct")
     if fan_speed is not None and printer.print_job is not None:
         printer.print_job.fan_speed = fan_speed
         print(f"+++ Printer {printer.id} fan speed: {fan_speed}%")
+        return True
+    return False
 
 
 def file_message(printer: Printer, payload):
@@ -357,20 +360,25 @@ def parse_message(mqtt_client, userdata, message):
         printer_updated = True
     # Parse message
     if action == "report":
-        printer_updated = True
         if type == "status":
+            printer_updated = True
             status_message(this_printer, payload["state"])
         elif type == "tempature":  # tempature is not a typo, it's how the API spells it
+            printer_updated = True
             temperature_message(this_printer, payload)
         elif type == "file":
+            printer_updated = True
             file_message(this_printer, payload)
         elif type == "print":
+            printer_updated = True
             print_message(this_printer, payload)
         elif type == "ota":
+            printer_updated = True
             ota_message(this_printer, payload)
         elif type == "fan":
-            fan_message(this_printer, payload)
+            printer_updated = fan_message(this_printer, payload)
         elif type == "lastWill":
+            printer_updated = True
             lastwill_message(this_printer, payload)
         else:
             print(f"Unknown message type: {type}/{action}")

--- a/main.py
+++ b/main.py
@@ -376,7 +376,7 @@ def parse_message(mqtt_client, userdata, message):
             printer_updated = True
             ota_message(this_printer, payload)
         elif type == "fan":
-            printer_updated = fan_message(this_printer, payload)
+            printer_updated = fan_message(this_printer, payload) or printer_updated
         elif type == "lastWill":
             printer_updated = True
             lastwill_message(this_printer, payload)


### PR DESCRIPTION
## Problem

`fan/report` MQTT messages arrive at kobra-unleashed but are silently dropped — `parse_message()` has no `fan` type handler, so they fall through to `Unknown message type`. The frontend never receives fan speed updates from these messages.

## Fix

- Add `fan_message()` handler that reads `data.fan_speed_pct` and updates the active `PrintJob.fan_speed`
- Add `fan` type routing in `parse_message()`

The handler safely no-ops when there's no active print job or when `fan_speed_pct` is missing from the payload.

Fixes cardil/kobra-unleashed#7
Related: cardil/ak2-dashboard#10

Assisted-by: 🤖 Claude Opus/Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle `fan/report` MQTT messages by adding a `fan_message()` handler and routing in `parse_message()`. Update `PrintJob.fan_speed` from `data.fan_speed_pct`, guard against missing `data`, set `printer_updated` only when a speed is applied, and preserve an existing `printer_updated` flag on fan no-ops to avoid clearing updates; fixes cardil/kobra-unleashed#7.

<sup>Written for commit cea532602b0fa607963fbf58b1c7a4c5ab1cc917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cardil/kobra-unleashed/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for monitoring printer fan speed in real-time during print operations. Fan speed data is now captured from incoming messages and logged for tracking purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->